### PR TITLE
#3: Mark lazy getproperty as configurable and enumerable to allow the…

### DIFF
--- a/infobox/src/infobox.es6
+++ b/infobox/src/infobox.es6
@@ -847,6 +847,8 @@ function lazy(target, properties, provider) {
         target,
         property,
         {
+            configurable: true,
+            enumerable: true,
             get: function () {
                 let source = provider();
                 delete target[property];


### PR DESCRIPTION
… get functionality to behave correctly.
